### PR TITLE
Update home page to affirm that it's really 2016

### DIFF
--- a/app/views/static_pages/home.html.haml
+++ b/app/views/static_pages/home.html.haml
@@ -1,6 +1,14 @@
 %section.main-content
   %p
-    AndConf (formerly &:conf) is a code retreat and an
+    AndConf will be back,
+    %b August 12-14th, 2016!
+    If you're interested in attending, sign up for our
+    #{link_to "mailing list", "http://eepurl.com/bAuGZb"}
+    and we'll let you know when registration opens.
+
+  %h2 What is AndConf?
+  %p
+    AndConf (formerly &:conf) is a code retreat and
     unconference for intersectional feminist programmers in the woods of western
     Sonoma County, CA. Saturday’s code retreat will
     be a day of pair programming on one kata where each hour we throw our
@@ -13,7 +21,6 @@
     camp and retreat center.
 
   %h2 Sponsorship
-
   %p
     We're actively seeking sponsors for AndConf 2016! Check out our
     #{ link_to "sponsorship prospectus", "/andconf_prospectus.pdf", target: "_blank" }, and email
@@ -32,29 +39,26 @@
     Read the #{ link_to "full code of conduct", code_of_conduct_path }.
 
   %h2 Contact
-
-  %p Questions? Contact the conference organizers at #{ mail_to "info@andconf.io" }.
-
   %p
-    Sign up for our #{link_to "mailing list", "http://eepurl.com/bAuGZb", target: "_blank"} for updates
-    about AndConf!
+    Questions? Check out the #{ link_to "faq", details_path } and if that doesn't
+    answer it, ontact the conference organizers at #{ mail_to "info@andconf.io" }.
 
   %h2 About the Organizers
   %p.bio
     = image_tag "lillie.jpg", alt: "Lillie Chilen"
     = link_to "Lillie Chilen", "https://twitter.com/lilliealbert", target: "_blank"
-    is a software engineer at Omada Health and a veteran open source event
-    organizer. She chairs the RailsBridge board and is the CTO of Double Union, a feminist
-    hacker/makerspace in San Francisco.
+    is a software engineer, Rubyist, and process junkie at Omada Health. She
+    co-organizes SF.rb, chairs the RailsBridge board and is the CTO of Double Union, a
+    feminist hacker/makerspace in San Francisco.
   %p.bio
     = image_tag "stella.jpg", alt: "Stella Cotton"
     = link_to "Stella Cotton", "https://twitter.com/practice_cactus", target: "_blank"
-    is a software engineer and project lead at Indiegogo. Coming to
-    software after six years in the Financial sector, she’s passionate about building robust
-    payments systems and diverse teams.
+    is a software engineer at Indiegogo, conference speaker, and co-organizer of
+    SF.rb. Coming to software after six years in the Financial sector, she’s
+    passionate about building robust payments systems and diverse teams.
   %p.bio
     = image_tag "emily.jpg", alt: "Emily Nakashima"
     = link_to "Emily Nakashima", "https://twitter.com/eanakashima", target: "_blank"
-    is a software engineer at GitHub and a volunteer with RailsBridge.
-    She writes and speaks at conferences on the topics of web performance, client-side
-    monitoring, javascript patterns, and supporting diversity in technical organizations.
+    leads the front end engineering team at Bugsnag. She writes and speaks at
+    conferences on the topics of web performance, client-side monitoring,
+    javascript patterns, and supporting diversity in technical organizations.


### PR DESCRIPTION
Just some copy tweaks that I'd like to ship ahead of posting the announcement blog post. Also pulls in our updated bios from the prospectus.
