### PR TITLE
Log sending reminder emails in Bugsnag

### DIFF
--- a/app/service_objects/account_setup_reminder.rb
+++ b/app/service_objects/account_setup_reminder.rb
@@ -9,11 +9,30 @@ class AccountSetupReminder
       processed_at = user.application.processed_at
       if processed_at < 2.days.ago && processed_at > 4.days.ago
         SignupReminderMailer.three_day_reminder(user).deliver_now
+        log_to_bugsnag(3, user.email)
       elsif processed_at < 5.days.ago && processed_at > 7.days.ago
         SignupReminderMailer.six_day_reminder(user).deliver_now
+        log_to_bugsnag(6, user.email)
       elsif processed_at < 8.days.ago && processed_at > 10.days.ago
         SignupReminderMailer.nine_day_reminder(user).deliver_now
+        log_to_bugsnag(9, user.email)
       end
+    end
+  end
+
+  private
+
+  def log_to_bugsnag(day_num, email)
+    err = BugsnagError.new("Sent #{day_num}-day reminder email")
+
+    err.bugsnag_meta_data = {
+      user_info: {
+        email: email
+      }
+    }
+
+    Bugsnag.notify(err) do |notif|
+      notif.severity = 'info'
     end
   end
 end

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -2,3 +2,7 @@ Bugsnag.configure do |config|
   config.api_key = "25494b0dde8f7d4d7594349f1bfdece9"
   config.notify_release_stages = ["staging", "production"]
 end
+
+class BugsnagError < RuntimeError
+  include Bugsnag::MetaData
+end


### PR DESCRIPTION
@lilliealbert I could use some opinions here. This should let us log to Bugsnag every time we send a reminder email, so we can see who got which email when. Does that sound handy, or TMI?
