### PR TITLE
Confirmed application can transition to a declined state

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -55,6 +55,10 @@ class Application < ActiveRecord::Base
       ApplicationsMailer.declined(application).deliver_now
     end
 
+    after_transition confirmed: :declined do |application|
+      application.user.make_applicant
+    end
+
     event :submit do
       transition started: :submitted
     end
@@ -73,6 +77,7 @@ class Application < ActiveRecord::Base
 
     event :decline do
       transition approved: :declined
+      transition confirmed: :declined
     end
 
     state :started

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,7 @@ class User < ActiveRecord::Base
   state_machine :state, initial: :visitor do
     event :make_applicant do
       transition visitor: :applicant
+      transition attendee: :applicant
     end
 
     event :make_attendee do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -25,6 +25,10 @@ FactoryGirl.define do
       is_admin true
       state "application_reviewer"
     end
+
+    factory :visitor do
+      state "visitor"
+    end
   end
 
   factory :vote do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -78,4 +78,32 @@ describe Application do
       expect(application.rejectable?).to be_truthy
     end
   end
+
+  describe "#decline" do
+    subject { application.decline }
+
+    context "application is approved" do
+      let(:application) { create(:approved_application) }
+
+      it "sends the organizers a declined email" do
+        expect { subject }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+
+      it "doesn't change the user state" do
+        expect { subject }.to_not change { application.user.state }
+      end
+    end
+
+    context "application is confirmed" do
+      let(:application) { create(:confirmed_application) }
+
+      it "doesn't send the organizers a declined email" do
+        expect { subject }.to_not change(ActionMailer::Base.deliveries, :count)
+      end
+
+      it "returns the user to the applicant state" do
+        expect { subject }.to change { application.user.state }.from("attendee").to("applicant")
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,15 +26,24 @@ describe User do
     expect(User.new.state).to eq('visitor')
   end
 
-  it 'should transition from visitor to applicant' do
-    user = User.new
-    user.username = 'sallyride'
-    user.email = 'cat@example.org'
-    user.save!
+  describe "#make_applicant" do
+    subject { applicant.make_applicant }
 
-    expect(user.state).to eq('visitor')
-    user.make_applicant!
-    expect(user.state).to eq('applicant')
+    context "new applicant" do
+      let(:applicant) { create(:visitor) }
+
+      it "should transition from visitor to applicant" do
+        expect { subject }.to change { applicant.state }.from("visitor").to("applicant")
+      end
+    end
+
+    context "attendee declines to attend" do
+      let(:applicant) { create(:attendee) }
+
+      it "should transition from attendee to applicant" do
+        expect { subject }.to change { applicant.state }.from("attendee").to("applicant")
+      end
+    end
   end
 
   describe "#make_attendee" do


### PR DESCRIPTION
In this scenario, someone has cancelled after already registering for
AndConf. This allows the application to transition to a "declined" state
and returns the user to the "applicant" state, making the application
and user states consistent with the behavior of declining prior to
registration. This does NOT delete the attendance record.
